### PR TITLE
update: make router paths kebab-case

### DIFF
--- a/template/ui/dev/src/router/pages.js
+++ b/template/ui/dev/src/router/pages.js
@@ -2,6 +2,13 @@
  * Export files list for /pages folder
  */
 
+function kebabCase (str) {
+  return str.replace(
+    /[A-Z\u00C0-\u00D6\u00D8-\u00DE]/g,
+    match => '-' + match.toLowerCase()
+  ).substring(1)
+}
+
 export default require.context('../pages', true, /^\.\/.*\.vue$/)
   .keys()
   .map(page => page.slice(2).replace('.vue', ''))
@@ -9,5 +16,5 @@ export default require.context('../pages', true, /^\.\/.*\.vue$/)
   .map(page => ({
     file: page,
     title: page + '.vue',
-    path: page.toLowerCase()
+    path: kebabCase(page)
   }))


### PR DESCRIPTION
When a page is Pascal-case (ie: ColorizeBackgroundSelection) the current path is
`http://localhost:8080/colorizebackgroundselection` and turns it into `http://localhost:8080/colorize-background-selection`