### PR TITLE
Add jsconfig for better code hints in VSCode

### DIFF
--- a/template/jsconfig.json
+++ b/template/jsconfig.json
@@ -1,0 +1,11 @@
+
+{
+  "compilerOptions": {
+    // This must be specified if "paths" is set
+    "baseUrl": ".",
+    // Relative to "baseUrl"
+    "paths": {
+      "ui/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
This jsconfig file is required in VSCode to be able to see code hints and to be able to command+click on what you import from `'ui'`

<img width="350" alt="Screenshot 2019-10-19 22 12 55" src="https://user-images.githubusercontent.com/3253920/67145603-ba4f2300-f2bd-11e9-8390-0cc043260bd7.png">
