### PR TITLE
feat(build): sync quasar-ui version to quasar-app-extension

### DIFF
--- a/template/ui/build/index.js
+++ b/template/ui/build/index.js
@@ -10,6 +10,7 @@ const { green, blue } = require('chalk')
 
 console.log()
 
+require('./script.app-ext').syncAppExt()
 require('./script.clean.js')
 
 console.log(` 📦 Building ${green('v' + require('../package.json').version)}...{{#or componentCss directiveCss}}${parallel ? blue(' [multi-threaded]') : ''}{{/or}}\n`)

--- a/template/ui/build/script.app-ext.js
+++ b/template/ui/build/script.app-ext.js
@@ -1,0 +1,60 @@
+const
+  fs = require('fs'),
+  path = require('path'),
+  root = path.resolve(__dirname, '../..'),
+  resolvePath = file => path.resolve(root, file),
+  { blue } = require('chalk')
+
+const writeJson = function (file, json) {
+  return fs.writeFileSync(file, JSON.stringify(json, null, 2) + '\n', 'utf-8')
+}
+
+module.exports.syncAppExt = function (both = true) {
+  // make sure this project has an app-extension project
+  const appExtDir = resolvePath('app-extension')
+  if (!fs.existsSync(appExtDir)) {
+    return
+  }
+
+  // make sure this project has an ui project
+  const uiDir = resolvePath('ui')
+  if (!fs.existsSync(uiDir)) {
+    return
+  }
+
+  // get version and name from ui package.json
+  const { name, version } = require(resolvePath(resolvePath('ui/package.json')))
+
+  // read app-ext package.json
+  const appExtFile = resolvePath('app-extension/package.json')
+  let appExtJson = require(appExtFile),
+    finished = false
+
+  // sync version numbers
+  if (both === true) {
+    appExtJson.version = version
+  }
+
+  // check dependencies
+  if (appExtJson.dependencies !== void 0) {
+    if (appExtJson.dependencies[name] !== void 0) {
+      appExtJson.dependencies[name] = '^' + version
+      finished = true
+    }
+  }
+  // check devDependencies, if not finished
+  if (finished === false && appExtJson.devDependencies !== void 0) {
+    if (appExtJson.devDependencies[name] !== void 0) {
+      appExtJson.devDependencies[name] = '^' + version
+      finished = true
+    }
+  }
+
+  if (finished === true) {
+    writeJson(appExtFile, appExtJson)
+    console.log(` ⭐️ App Extension ${blue(appExtJson.name)} synced.\n`)
+    return
+  }
+
+  console.error(`   App Extension version and dependency NOT synced.\n`)
+}


### PR DESCRIPTION
The new code will look for both app-extension and ui and on a build. If both are found, it will sync the ui version in dependencies/devDependencies. Optionally (based n setting), will also sync the app-extension version to be the same as the ui version. This is based on tedious take of manually syncing, of which has been missed in the past by several developers, to streamline this process.