### PR TITLE
refactor(build): file extension consistency

### DIFF
--- a/template/ui/build/index.js
+++ b/template/ui/build/index.js
@@ -11,7 +11,7 @@ const { green, blue } = require('chalk')
 console.log()
 
 {{#features.ae}}
-require('./script.app-ext').syncAppExt()
+require('./script.app-ext.js').syncAppExt()
 {{/features.ae}}
 require('./script.clean.js')
 
@@ -20,8 +20,8 @@ console.log(` 📦 Building ${green('v' + require('../package.json').version)}..
 createFolder('dist')
 
 {{#or componentCss directiveCss}}
-runJob(join(__dirname, './script.javascript'))
-runJob(join(__dirname, './script.css'))
+runJob(join(__dirname, './script.javascript.js'))
+runJob(join(__dirname, './script.css.js'))
 {{else}}
-require(join(__dirname, './script.javascript'))
+require(join(__dirname, './script.javascript.js'))
 {{/or}}


### PR DESCRIPTION
only `'./script.clean.js'` had `.js` behind it. I've added it to the other files as well.

We should try to be consistent. Either use `.js` behind everything or nothing. I personally prefer explicitly but feel free to remove all `.js` extensions as well.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasar-framework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
