### PR TITLE
chore: update rollup-plugin-node-resolve to @rollup/plugin-node-resolve

### DIFF
--- a/template/ui/build/script.javascript.js
+++ b/template/ui/build/script.javascript.js
@@ -5,7 +5,7 @@ const rollup = require('rollup')
 const uglify = require('uglify-es')
 const buble = require('@rollup/plugin-buble')
 const json = require('@rollup/plugin-json')
-const nodeResolve = require('rollup-plugin-node-resolve')
+const nodeResolve = require('@rollup/plugin-node-resolve')
 
 const buildConf = require('./config')
 const buildUtils = require('./utils')

--- a/template/ui/package.json
+++ b/template/ui/package.json
@@ -7,12 +7,12 @@
   "module": "dist/index.esm.js",
   "main": "dist/index.common.js",
   "scripts": {
-    "dev": "cd dev; yarn dev; cd ..",
+    "dev": "cd dev && yarn dev && cd ..",
     "dev:umd": "yarn build && node build/script.open-umd.js",
-    "dev:ssr": "cd dev; yarn 'dev:ssr'; cd ..",
-    "dev:ios": "cd dev; yarn 'dev:ios'; cd ..",
-    "dev:android": "cd dev; yarn 'dev:android'; cd ..",
-    "dev:electron": "cd dev; yarn 'dev:electron'; cd ..",
+    "dev:ssr": "cd dev && yarn 'dev:ssr' && cd ..",
+    "dev:ios": "cd dev && yarn 'dev:ios' && cd ..",
+    "dev:android": "cd dev && yarn 'dev:android' && cd ..",
+    "dev:electron": "cd dev && yarn 'dev:electron' && cd ..",
     "build": "node build/index.js",
     "build:js": "node build/script.javascript.js"{{#or componentCss directiveCss}},
     "build:css": "node build/script.css.js"{{/or}}

--- a/template/ui/package.json
+++ b/template/ui/package.json
@@ -39,7 +39,7 @@
     "rollup": "^1.21.3",
     "@rollup/plugin-buble": "^0.20.0",
     "@rollup/plugin-json": "^4.0.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
+    "@rollup/plugin-node-resolve": "^6.0.0",
     "uglify-es": "^3.3.9",
     "zlib": "^1.0.5"
   },


### PR DESCRIPTION
Deprecated: https://www.npmjs.com/package/rollup-plugin-node-resolve?activeTab=readme
Active: https://github.com/rollup/plugins/tree/master/packages/node-resolve